### PR TITLE
fix(build): avoid duplicate ONNX Runtime WASM

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,7 +1,35 @@
 import { defineConfig } from 'wxt';
 
 export default defineConfig({
+  vite: () => ({
+    resolve: {
+      conditions: [
+        'module',
+        'browser',
+        'development|production',
+        'onnxruntime-web-use-extern-wasm',
+      ],
+    },
+  }),
   hooks: {
+    'build:done': (_wxt, output) => {
+      const ortWasmFiles = [
+        ...output.publicAssets,
+        ...output.steps.flatMap((step) => step.chunks),
+      ]
+        .map((file) => file.fileName)
+        .filter((fileName) =>
+          fileName.includes('ort-wasm-simd-threaded') && fileName.endsWith('.wasm'),
+        );
+      if (
+        ortWasmFiles.length !== 1 ||
+        ortWasmFiles[0] !== 'ort/ort-wasm-simd-threaded.wasm'
+      ) {
+        throw new Error(
+          `Expected one external ONNX Runtime WASM asset, received: ${ortWasmFiles.join(', ')}`,
+        );
+      }
+    },
     'entrypoints:found': (_wxt, entrypoints) => {
       const companionScript = entrypoints.findIndex((entrypoint) =>
         entrypoint.inputPath.endsWith('/entrypoints/offscreen.ts'),


### PR DESCRIPTION
Select ONNX Runtime's external-WASM export so WXT does not emit a second 13.48 MB copy. Add a build hook that fails if the runtime WASM is duplicated again.\n\nVerified: typecheck, 594 unit tests, Chrome/Edge builds, extension E2E, Chrome/Edge offline recognition, and release ZIP generation.